### PR TITLE
Make v9 ready

### DIFF
--- a/controllers/single_page/account/orders.php
+++ b/controllers/single_page/account/orders.php
@@ -114,8 +114,10 @@ class Orders extends PageController {
 		$orderChoicesAttList = StoreOrderKey::getAttributeListBySet('order_choices', $u);
 		$orderChoicesEnabled = count($orderChoicesAttList)? true : false;
 
+		$filesystem = new \Illuminate\Filesystem\Filesystem();
+
 		ob_start();
-		if (Filesystem::exists(DIR_BASE. '/application/elements/customer_order_slip.php')) {
+		if ($filesystem->exists(DIR_BASE. '/application/elements/customer_order_slip.php')) {
 			View::element('customer_order_slip', array('order' => $o, 'orderChoicesEnabled' => $orderChoicesEnabled, 'orderChoicesAttList' => $orderChoicesAttList));
 		} else {
 			View::element('customer_order_slip', array('order' => $o, 'orderChoicesEnabled' => $orderChoicesEnabled, 'orderChoicesAttList' => $orderChoicesAttList), 'community_store_order_history');

--- a/elements/customer_order_slip.php
+++ b/elements/customer_order_slip.php
@@ -1,17 +1,23 @@
 <?php
 defined('C5_EXECUTE') or die("Access Denied.");
-use \Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Price as Price;
-use \Concrete\Package\CommunityStore\Src\Attribute\Key\StoreOrderKey as StoreOrderKey;
 
-$dh = Core::make('helper/date');
+use \Concrete\Core\Support\Facade\Url;
+use \Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Price;
+
+$app = \Concrete\Core\Support\Facade\Application::getFacadeApplication();
+$dh = $app->make('helper/date');
 
 ?>
 <!doctype html>
 <html>
 <head>
     <title><?= t("Order #") . $order->getOrderID() ?></title>
-    <link href="<?= str_replace('/index.php/', '/' , \URL::to('/concrete/css/app.css')); ?>" rel="stylesheet" type="text/css" media="all">
-    <style>
+    <?php
+    if (version_compare($app->make('config')->get('concrete.version'), '9.0', '<')) { ?>
+    <link href="<?= str_replace('/index.php/', '/' , Url::to('/concrete/css/app.css')); ?>" rel="stylesheet" type="text/css" media="all">
+    <?php } else { ?>
+    <link href="<?= str_replace('/index.php/', '/' , Url::to('/concrete/css/cms.css')); ?>" rel="stylesheet" type="text/css" media="all">
+    <?php } ?>    <style>
         td, th {
             font-size: 14px;
         }


### PR DESCRIPTION
I have changed two things in order to reflect v9 changes:

1. Change the singlepage controller to check for the custom template with a non-static way as the app requires
2. Add a checker for the concrete version to determine where to find the base css (app.css / cms.css) 